### PR TITLE
Handle encoded slash in path params

### DIFF
--- a/router_serve.go
+++ b/router_serve.go
@@ -202,7 +202,7 @@ func calculateRoute(rootRouter *Router, req *Request) (*route, map[string]string
 	}
 
 	if isRawPath {
-		// Unescape wildcard values since RawPath used
+		// Unescape wildcard values since RawPath was used
 		for key, value := range wildcardMap {
 			if unescapedValue, err := url.QueryUnescape(value); err == nil {
 				wildcardMap[key] = unescapedValue

--- a/router_serve_test.go
+++ b/router_serve_test.go
@@ -1,9 +1,12 @@
 package web
 
 import (
+	"io/ioutil"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCalculateRoutePath(t *testing.T) {
@@ -36,4 +39,35 @@ func TestCalculateRoutePath(t *testing.T) {
 	assert.Panics(t, func() {
 		CalculateRoutePath(r, "unknown http method", "/hello/babe/and/goodbye/1")
 	})
+}
+
+func TestEncodedRoutes(t *testing.T) {
+	type MyContext struct{}
+
+	router := New(MyContext{})
+	router.Get("/testPath/:id/suffix", func(ctx *MyContext, rw ResponseWriter, req *Request) {
+		_, _ = rw.Write([]byte(req.PathParams["id"]))
+	})
+	router.Get("/testPath/:id/%2F", func(ctx *MyContext, rw ResponseWriter, req *Request) {
+		_, _ = rw.Write([]byte("two-f"))
+	})
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	c := srv.Client()
+
+	getResponseBodyString := func(path string) string {
+		resp, err := c.Get(srv.URL + path)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		all, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		return string(all)
+	}
+
+	assert.Equal(t, "id", getResponseBodyString("/testPath/id/suffix"))
+	assert.Equal(t, "id", getResponseBodyString("/testPath/id/suffix?params=%2F"))
+	assert.Equal(t, "two-f", getResponseBodyString("/testPath/id/%2F"))
+	assert.Equal(t, "id with spaces", getResponseBodyString("/testPath/id%20with%20spaces/suffix"))
+	assert.Equal(t, "id/with/slashes", getResponseBodyString("/testPath/id%2Fwith%2Fslashes/suffix"))
 }


### PR DESCRIPTION
Валер, ты уже смотрел что-то по этому роутеру, глянь этот фиксец.
Альберт, ты в курсе проблемы, тоже глянь на всякий.
До этого исправления кейс теста "id/with/slashes" не работал. Вроде бы ничего не должно разъебать.